### PR TITLE
feat: establish testing framework

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,15 @@
+# Code Review
+
+## Engineer Review
+- ✅ `ruff check .` returned no issues.
+- ✅ `bandit -r src` found no security issues.
+- ❌ Tests initially failed because package was not installed; after `pip install -e .`, tests passed.
+- No nested loops or obvious performance smells were found in the codebase.
+
+## Product Review
+- Acceptance criteria from `tests/sprint_acceptance_criteria.json` require a success case and null input edge case.
+- The tests in `tests/test_foundational.py` cover both cases and pass after installing the package.
+- The README mentions an architecture diagram, but there is no `ARCHITECTURE.md` file in the repo, so architectural documentation is missing.
+
+## Summary
+The implementation meets the sprint acceptance criteria and passes code quality checks. The commit message could be more descriptive, and architectural documentation is absent.

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,0 +1,13 @@
+# Development Plan
+
+## Phase 1: Foundational Setup
+- [ ] **Foundational:** Establish a testing framework (`pytest`, etc.) with initial tests.
+
+## Phase 2: Core Feature Implementation
+- [ ] **Feature:** Implement core API endpoints as described in the README.
+
+## Phase 3: Review & Refinement
+
+
+## Completed Tasks
+

--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -1,0 +1,6 @@
+# Sprint Board
+
+## Backlog
+| Task | Owner | Priority | Status |
+| --- | --- | --- | --- |
+| Establish a testing framework (`pytest`, etc.) with initial tests. | @agent | P0 | Done |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "crewai-email-triage"
+version = "0.1.0"
+description = "Smart email assistant that classifies, prioritizes, summarizes, and drafts replies."
+authors = [{name = "Codex", email = "codex@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/crewai_email_triage/__init__.py
+++ b/src/crewai_email_triage/__init__.py
@@ -1,0 +1,5 @@
+"""CrewAI Email Triage package."""
+
+from .core import process_email
+
+__all__ = ["process_email"]

--- a/src/crewai_email_triage/core.py
+++ b/src/crewai_email_triage/core.py
@@ -1,0 +1,21 @@
+"""Core functionality for CrewAI Email Triage."""
+
+from __future__ import annotations
+
+
+def process_email(content: str | None) -> str:
+    """Process an email and return a simple acknowledgment string.
+
+    Parameters
+    ----------
+    content: str | None
+        The email content to process. If ``None``, returns an empty string.
+
+    Returns
+    -------
+    str
+        A simple acknowledgment string.
+    """
+    if content is None:
+        return ""
+    return f"Processed: {content.strip()}"

--- a/tests/sprint_acceptance_criteria.json
+++ b/tests/sprint_acceptance_criteria.json
@@ -1,0 +1,10 @@
+{
+  "establish-a-testing-framework-(`pytest`,-etc.)-with-initial-tests.": {
+    "test_file": "tests/test_foundational.py",
+    "description": "Verifies that Establish a testing framework (`pytest`, etc.) with initial tests.",
+    "cases": {
+      "success": "Asserts the primary success case.",
+      "edge_case_null_input": "Asserts that providing null input is handled gracefully."
+    }
+  }
+}

--- a/tests/test_foundational.py
+++ b/tests/test_foundational.py
@@ -1,0 +1,9 @@
+from crewai_email_triage import process_email
+
+
+def test_success():
+    assert process_email("Hello") == "Processed: Hello"
+
+
+def test_edge_case_null_input():
+    assert process_email(None) == ""


### PR DESCRIPTION
## Summary
- set up project package with `pyproject.toml`
- implement `process_email` example helper
- add initial pytest suite
- mark testing framework task as done
- add code review report

## Testing
- `ruff check .`
- `bandit -r src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858711314048329ba24d109009617f4

## Summary by Sourcery

Establish project scaffold with packaging, core email processing helper, initial test framework, and supporting documentation

New Features:
- Implement core `process_email` helper to return acknowledgment for given email content

Enhancements:
- Configure project packaging and dependencies via `pyproject.toml`

Build:
- Add `pyproject.toml` to define build-system and project metadata

Documentation:
- Add `CODE_REVIEW.md` with QA and product feedback
- Add `DEVELOPMENT_PLAN.md` outlining project phases
- Add `SPRINT_BOARD.md` for task tracking

Tests:
- Add initial pytest suite covering normal and null input cases
- Include sprint acceptance criteria JSON fixture for tests