### PR TITLE
Add message source check to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ cat result.json
 # => {"category": "urgent", "priority": 10, ...}
 
 # One of --message, --stdin, --file, or --batch-file is required
+# These options are mutually exclusive
 
 # Or read the message from standard input
 echo "Quarterly report needed ASAP!" | python triage.py --stdin

--- a/README.md
+++ b/README.md
@@ -24,12 +24,36 @@ Incoming Email → Classifier Agent → Priority Agent → Summarizer Agent → 
 ```bash
 # Install dependencies
 pip install -r requirements.txt
+# Install the package in editable mode
+pip install -e .
 
 # Configure email credentials
 python setup.py --provider gmail
 
-# Run email triage
-python triage.py --inbox --limit 50
+# Run email triage on a single message
+python triage.py --message "Quarterly report needed ASAP!"
+# => {"category": "urgent", "priority": 10, ...}
+
+# Pretty-print the result
+python triage.py --message "Quarterly report needed ASAP!" --pretty
+
+# Save the result to a file
+python triage.py --message "Quarterly report needed ASAP!" --output result.json
+cat result.json
+# => {"category": "urgent", "priority": 10, ...}
+
+# One of --message, --stdin, --file, or --batch-file is required
+
+# Or read the message from standard input
+echo "Quarterly report needed ASAP!" | python triage.py --stdin
+
+# Or read the message from a file
+echo "Quarterly report needed ASAP!" > email.txt
+python triage.py --file email.txt
+
+# Process multiple messages from a file
+echo -e "Urgent meeting tomorrow!\nAnother message" > batch.txt
+python triage.py --batch-file batch.txt
 ```
 
 ## Agent Crew
@@ -39,10 +63,12 @@ python triage.py --inbox --limit 50
 - **Goal**: Accurately classify emails into categories (work, personal, spam, urgent, etc.)
 - **Tools**: Text analysis, sender reputation, keyword matching
 
-### Priority Agent  
+### Priority Agent
 - **Role**: Urgency Assessment Expert
 - **Goal**: Score emails by importance and time sensitivity
 - **Tools**: Deadline detection, sender importance, content analysis
+- **Heuristics**: "urgent" or all-caps text yields score 10; keywords like
+  "deadline" or an exclamation mark score 8; otherwise 5.
 
 ### Summarizer Agent
 - **Role**: Content Distillation Specialist
@@ -53,6 +79,17 @@ python triage.py --inbox --limit 50
 - **Role**: Communication Specialist
 - **Goal**: Draft appropriate replies maintaining tone and context
 - **Tools**: Template matching, tone analysis, personalization
+
+### Triage Pipeline
+Use ``triage_email`` to run all agents in sequence:
+
+```python
+from crewai_email_triage import triage_email
+
+result = triage_email("Quarterly report needed ASAP!")
+print(result)
+# {'category': 'urgent', 'priority': 10, 'summary': 'Quarterly report needed ASAP!', 'response': 'Thanks for your email'}
+```
 
 ## Configuration
 
@@ -105,6 +142,13 @@ python triage.py --folder "Important"
 ```bash
 # Review and approve actions
 python triage.py --interactive
+
+# Type a message and press Enter
+Quarterly report needed ASAP!
+{"category": "urgent", "priority": 10, "summary": "Quarterly report needed ASAP!", "response": "Thanks for your email"}
+
+# Submit an empty line to quit
+# Or press Ctrl+C
 
 # Generate reports
 python triage.py --report --date-range "last_week"

--- a/src/crewai_email_triage/__init__.py
+++ b/src/crewai_email_triage/__init__.py
@@ -5,6 +5,8 @@ from .agent import Agent
 from .classifier import ClassifierAgent
 from .summarizer import SummarizerAgent
 from .response import ResponseAgent
+from .priority import PriorityAgent
+from .pipeline import triage_email
 
 __all__ = [
     "process_email",
@@ -12,4 +14,6 @@ __all__ = [
     "ClassifierAgent",
     "SummarizerAgent",
     "ResponseAgent",
+    "PriorityAgent",
+    "triage_email",
 ]

--- a/src/crewai_email_triage/pipeline.py
+++ b/src/crewai_email_triage/pipeline.py
@@ -1,0 +1,32 @@
+"""Simple pipeline orchestrating all agents."""
+
+from __future__ import annotations
+
+from .classifier import ClassifierAgent
+from .priority import PriorityAgent
+from .summarizer import SummarizerAgent
+from .response import ResponseAgent
+
+
+def triage_email(content: str | None) -> dict[str, str | int]:
+    """Run email ``content`` through all agents and collect results."""
+    classifier = ClassifierAgent()
+    prioritizer = PriorityAgent()
+    summarizer = SummarizerAgent()
+    responder = ResponseAgent()
+
+    cat = classifier.run(content).replace("category: ", "")
+    pri = prioritizer.run(content).replace("priority: ", "")
+    try:
+        priority_score = int(pri)
+    except ValueError:
+        priority_score = 0
+    summary = summarizer.run(content).replace("summary: ", "")
+    response = responder.run(content).replace("response: ", "")
+
+    return {
+        "category": cat,
+        "priority": priority_score,
+        "summary": summary,
+        "response": response,
+    }

--- a/src/crewai_email_triage/priority.py
+++ b/src/crewai_email_triage/priority.py
@@ -1,0 +1,44 @@
+"""Simple priority agent for assessing email urgency."""
+
+from __future__ import annotations
+
+from .agent import Agent
+
+
+HIGH_URGENCY = {
+    "urgent",
+    "asap",
+    "immediately",
+    "right away",
+    "high priority",
+}
+
+MEDIUM_URGENCY = {
+    "soon",
+    "important",
+    "deadline",
+    "tomorrow",
+    "today",
+    "eod",
+    "end of day",
+}
+
+
+class PriorityAgent(Agent):
+    """Agent that scores email urgency on a 1–10 scale."""
+
+    def run(self, content: str | None) -> str:
+        """Return a priority score for ``content`` using simple heuristics."""
+        if not content:
+            return "priority: 0"
+
+        normalized = content.lower()
+
+        if any(word in normalized for word in HIGH_URGENCY) or content.isupper():
+            score = 10
+        elif any(word in normalized for word in MEDIUM_URGENCY) or "!" in content:
+            score = 8
+        else:
+            score = 5
+
+        return f"priority: {score}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,100 @@
+import json
+import subprocess
+import sys
+
+
+def test_cli_message():
+    result = subprocess.run(
+        [sys.executable, "triage.py", "--message", "Urgent meeting tomorrow!"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = json.loads(result.stdout)
+    assert output["priority"] == 10
+
+
+def test_cli_output_file(tmp_path):
+    path = tmp_path / "out.json"
+    subprocess.run(
+        [sys.executable, "triage.py", "--message", "Urgent meeting tomorrow!", "--output", str(path)],
+        check=True,
+    )
+    output = json.loads(path.read_text())
+    assert output["priority"] == 10
+
+
+def test_cli_interactive():
+    proc = subprocess.Popen(
+        [sys.executable, "triage.py", "--interactive"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    stdout, _ = proc.communicate("Urgent meeting tomorrow!\n\n")
+    lines = [line for line in stdout.splitlines() if line.strip().startswith("{")]
+    output = json.loads(lines[-1])
+    assert output["priority"] == 10
+
+
+def test_cli_stdin():
+    result = subprocess.run(
+        [sys.executable, "triage.py", "--stdin"],
+        input="Urgent meeting tomorrow!",
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    output = json.loads(result.stdout)
+    assert output["priority"] == 10
+
+
+def test_cli_file(tmp_path):
+    msg_file = tmp_path / "msg.txt"
+    msg_file.write_text("Urgent meeting tomorrow!")
+    result = subprocess.run(
+        [sys.executable, "triage.py", "--file", str(msg_file)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = json.loads(result.stdout)
+    assert output["priority"] == 10
+
+
+def test_cli_batch_file(tmp_path):
+    batch_file = tmp_path / "batch.txt"
+    batch_file.write_text("Urgent meeting tomorrow!\nAnother message")
+    result = subprocess.run(
+        [sys.executable, "triage.py", "--batch-file", str(batch_file)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = json.loads(result.stdout)
+    assert isinstance(output, list)
+    assert output[0]["priority"] == 10
+    assert output[1]["priority"] == 5
+
+
+def test_cli_pretty():
+    result = subprocess.run(
+        [sys.executable, "triage.py", "--message", "Urgent meeting tomorrow!", "--pretty"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "\n" in result.stdout.strip()
+    output = json.loads(result.stdout)
+    assert output["priority"] == 10
+
+
+def test_cli_requires_message():
+    result = subprocess.run(
+        [sys.executable, "triage.py"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "one of --message" in result.stderr.lower()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,3 +98,22 @@ def test_cli_requires_message():
     assert result.returncode == 2
     assert "one of --message" in result.stderr.lower()
 
+
+def test_cli_mutually_exclusive(tmp_path):
+    msg_file = tmp_path / "msg.txt"
+    msg_file.write_text("hello")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "triage.py",
+            "--message",
+            "hi",
+            "--file",
+            str(msg_file),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert "mutually exclusive" in result.stderr.lower()
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,19 @@
+from crewai_email_triage import triage_email
+
+
+def test_success():
+    result = triage_email("This is urgent. Please review by tomorrow!")
+    assert result["category"] == "urgent"
+    assert result["priority"] == 10
+    assert result["summary"] == "This is urgent"
+    assert result["response"] == "Thanks for your email"
+
+
+def test_edge_case_invalid_input():
+    result = triage_email(None)
+    assert result == {
+        "category": "unknown",
+        "priority": 0,
+        "summary": "summary:",
+        "response": "response:",
+    }

--- a/tests/test_priority_agent.py
+++ b/tests/test_priority_agent.py
@@ -1,0 +1,26 @@
+from crewai_email_triage import PriorityAgent
+
+
+def test_success():
+    agent = PriorityAgent()
+    assert agent.run("This is urgent") == "priority: 10"
+
+
+def test_medium_priority():
+    agent = PriorityAgent()
+    assert agent.run("Project deadline tomorrow") == "priority: 8"
+
+
+def test_edge_case_invalid_input():
+    agent = PriorityAgent()
+    assert agent.run(None) == "priority: 0"
+
+
+def test_high_priority_uppercase():
+    agent = PriorityAgent()
+    assert agent.run("PLEASE RESPOND") == "priority: 10"
+
+
+def test_medium_priority_exclamation():
+    agent = PriorityAgent()
+    assert agent.run("Need this reviewed!") == "priority: 8"

--- a/triage.py
+++ b/triage.py
@@ -1,0 +1,107 @@
+import argparse
+import json
+import sys
+
+from crewai_email_triage import triage_email
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run email triage")
+    parser.add_argument(
+        "--message",
+        help="Email content to triage",
+    )
+    parser.add_argument(
+        "--output",
+        type=argparse.FileType("w"),
+        help="Write JSON result to the given file",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Run in interactive mode",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read message content from standard input",
+    )
+    parser.add_argument(
+        "--file",
+        type=argparse.FileType("r"),
+        help="Read message content from a file",
+    )
+    parser.add_argument(
+        "--batch-file",
+        type=argparse.FileType("r"),
+        help="Read multiple messages from a file, one per line",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output",
+    )
+    args = parser.parse_args()
+
+    if args.interactive:
+        while True:
+            try:
+                sys.stderr.write("message> ")
+                sys.stderr.flush()
+                line = input()
+            except EOFError:
+                break
+            except KeyboardInterrupt:
+                sys.stderr.write("\n")
+                break
+            if not line:
+                break
+            print(
+                json.dumps(
+                    triage_email(line),
+                    indent=2 if args.pretty else None,
+                )
+            )
+        return
+
+    message = args.message
+    sources = [
+        args.message is not None,
+        args.stdin,
+        args.file is not None,
+        args.batch_file is not None,
+    ]
+    if sum(1 for s in sources if s) > 1:
+        parser.error(
+            "--message, --stdin, --file, and --batch-file are mutually exclusive"
+        )
+    if not any(sources) and not args.interactive:
+        parser.error(
+            "one of --message, --stdin, --file, or --batch-file is required"
+        )
+
+    output_data = None
+    if args.batch_file:
+        messages = [line.strip() for line in args.batch_file if line.strip()]
+        args.batch_file.close()
+        results = [triage_email(msg) for msg in messages]
+        output_data = json.dumps(results, indent=2 if args.pretty else None)
+    else:
+        if args.stdin:
+            message = sys.stdin.read()
+        elif args.file:
+            message = args.file.read()
+            args.file.close()
+
+        result = triage_email(message)
+        output_data = json.dumps(result, indent=2 if args.pretty else None)
+
+    if args.output:
+        args.output.write(output_data + "\n")
+        args.output.close()
+    else:
+        print(output_data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure `triage.py` exits when no message source is provided
- document the requirement in the quick-start guide
- test CLI error behavior when no message is specified

## Testing
- `ruff check .`
- `bandit -r src -q`
- `python -m compileall -q src tests triage.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e886d973483299ed16d679a7bb0af

## Summary by Sourcery

Enable a fully featured CLI for email triage with enforced message‐source validation, integrate a priority scoring agent and pipeline function, update documentation to show new usage patterns, and add comprehensive tests.

New Features:
- Add a CLI script (triage.py) that accepts --message, --stdin, --file, --batch-file, --interactive, --pretty, and --output flags
- Introduce a PriorityAgent for email urgency scoring and a triage_email pipeline function to orchestrate classification, prioritization, summarization, and response

Bug Fixes:
- Validate that exactly one message source is specified and exit with an error if none or multiple are provided

Enhancements:
- Extend README with detailed usage examples for the new CLI options and document the input source requirement

Tests:
- Add end-to-end tests for the CLI, unit tests for PriorityAgent scoring rules, and integration tests for the triage_email pipeline