### PR TITLE
Fix version fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ python triage.py --message "Quarterly report needed ASAP!" --output result.json
 cat result.json
 # => {"category": "urgent", "priority": 10, ...}
 
-# One of --message, --stdin, --file, or --batch-file is required
+# Check the version
+python triage.py --version
+# => triage.py 0.1.0
+
+# Exactly one of --message, --stdin, --file, --batch-file, or --interactive is required
 # These options are mutually exclusive
 
 # Or read the message from standard input

--- a/src/crewai_email_triage/__init__.py
+++ b/src/crewai_email_triage/__init__.py
@@ -1,5 +1,9 @@
 """CrewAI Email Triage package."""
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from pathlib import Path
+import tomllib
+
 from .core import process_email
 from .agent import Agent
 from .classifier import ClassifierAgent
@@ -7,6 +11,24 @@ from .summarizer import SummarizerAgent
 from .response import ResponseAgent
 from .priority import PriorityAgent
 from .pipeline import triage_email
+
+
+
+def _read_version_from_pyproject() -> str:
+    """Return the version declared in ``pyproject.toml``."""
+    root = Path(__file__).resolve().parents[2]
+    with (root / "pyproject.toml").open("rb") as fh:
+        project = tomllib.load(fh)
+    return project["project"]["version"]
+
+
+try:  # Grab the installed package version if available
+    __version__ = _pkg_version("crewai_email_triage")
+except PackageNotFoundError:  # Local source without installation
+    try:
+        __version__ = _read_version_from_pyproject()
+    except Exception:
+        __version__ = "0.0.0"
 
 __all__ = [
     "process_email",
@@ -16,4 +38,5 @@ __all__ = [
     "ResponseAgent",
     "PriorityAgent",
     "triage_email",
+    "__version__",
 ]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,17 @@
+import importlib
+import importlib.metadata
+
+import crewai_email_triage
+from importlib.metadata import PackageNotFoundError
+
+
+def test_version_fallback(monkeypatch):
+    def raise_not_found(_: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_not_found)
+    importlib.reload(crewai_email_triage)
+    assert crewai_email_triage.__version__ == "0.1.0"
+
+    importlib.reload(crewai_email_triage)
+

--- a/triage.py
+++ b/triage.py
@@ -2,39 +2,45 @@ import argparse
 import json
 import sys
 
-from crewai_email_triage import triage_email
+from crewai_email_triage import __version__, triage_email
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run email triage")
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
         "--message",
         help="Email content to triage",
     )
-    parser.add_argument(
-        "--output",
-        type=argparse.FileType("w"),
-        help="Write JSON result to the given file",
+    group.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read message content from standard input",
     )
-    parser.add_argument(
+    group.add_argument(
+        "--file",
+        type=argparse.FileType("r"),
+        help="Read message content from a file",
+    )
+    group.add_argument(
+        "--batch-file",
+        type=argparse.FileType("r"),
+        help="Read multiple messages from a file, one per line",
+    )
+    group.add_argument(
         "--interactive",
         action="store_true",
         help="Run in interactive mode",
     )
     parser.add_argument(
-        "--stdin",
-        action="store_true",
-        help="Read message content from standard input",
-    )
-    parser.add_argument(
-        "--file",
-        type=argparse.FileType("r"),
-        help="Read message content from a file",
-    )
-    parser.add_argument(
-        "--batch-file",
-        type=argparse.FileType("r"),
-        help="Read multiple messages from a file, one per line",
+        "--output",
+        type=argparse.FileType("w"),
+        help="Write JSON result to the given file",
     )
     parser.add_argument(
         "--pretty",
@@ -65,20 +71,6 @@ def main() -> None:
         return
 
     message = args.message
-    sources = [
-        args.message is not None,
-        args.stdin,
-        args.file is not None,
-        args.batch_file is not None,
-    ]
-    if sum(1 for s in sources if s) > 1:
-        parser.error(
-            "--message, --stdin, --file, and --batch-file are mutually exclusive"
-        )
-    if not any(sources) and not args.interactive:
-        parser.error(
-            "one of --message, --stdin, --file, or --batch-file is required"
-        )
 
     output_data = None
     if args.batch_file:


### PR DESCRIPTION
## Summary
- simplify package version fallback logic
- add regression test for missing package metadata
- refine fallback to read version from `pyproject.toml` when metadata is missing

## Testing
- `ruff check .`
- `bandit -r src -q`
- `python -m compileall -q src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686000352d188329b997131423498df6

## Summary by Sourcery

Refine version handling by streamlining fallback logic and exposing a --version flag; reorganize CLI argument parsing into a mutually exclusive group; bolster coverage with new tests; and update documentation accordingly.

New Features:
- Add --version CLI flag to display the application version

Enhancements:
- Simplify package version fallback logic to prefer installed metadata and fall back to pyproject.toml or a default
- Consolidate input options (--message, --stdin, --file, --batch-file, --interactive) into a single mutually exclusive argument group

Documentation:
- Update README to include usage of the --version flag and note the exclusive argument requirements

Tests:
- Add regression tests for version fallback when package metadata is missing
- Extend CLI tests to cover --version flag, argument exclusivity, and error messaging